### PR TITLE
Use default R temp directory

### DIFF
--- a/R/read_qza.R
+++ b/R/read_qza.R
@@ -24,7 +24,7 @@
 
 read_qza <- function(file, tmp, rm) {
 
-if(missing(tmp)){tmp="/tmp/"}
+if(missing(tmp)){tmp <- tempdir()}
 if(missing(file)){stop("Path to artifact (.qza) not provided")}
 if(missing(rm)){rm=TRUE} #remove the decompressed object from tmp
 


### PR DESCRIPTION
Makes the function less likely to provide an error message and makes it run more smoothly on multiple operating systems. Windows does not like the previous default.