### PR TITLE
Fix import to phyloseq

### DIFF
--- a/R/qza_to_phyloseq.R
+++ b/R/qza_to_phyloseq.R
@@ -26,7 +26,7 @@ if(missing(tmp)){tmp <- tempdir()}
   argstring<-""
 
   if(!missing(features)){
-    features<-read_qza(features, tmp=tmp)$data
+    features<-as.data.frame(read_qza(features, tmp=tmp)$data)
     argstring<-paste(argstring, "otu_table(features, taxa_are_rows=T),")
   }
 


### PR DESCRIPTION
I've been having an issue (I think since an upgrade to R versions > 4.0) where `qza_to_phyloseq(features = "table.qza", taxonomy = "silva_132_taxonomy.qza")` returns this error:

> Error in (function (classes, fdef, mtable)  : 
  unable to find an inherited method for function ‘prune_samples’ for signature ‘"array", "phyloseq"’

It seems to be an [error with phyloseq](https://github.com/joey711/phyloseq/issues/1356), possibly related to [changes in how matrices are handled in newer versions of R](https://blog.revolutionanalytics.com/2020/04/r-400-is-released.html). Simply converting the imported matrix to dataframe before passing it to phyloseq::otu_table() seems to fix the issue.