### PR TITLE
add: error message for case when metadata file doesn't exist

### DIFF
--- a/R/is_q2metadata.R
+++ b/R/is_q2metadata.R
@@ -12,6 +12,9 @@
 #'
 
 is_q2metadata <- function(file){
+
+  if (!file.exists(file)){stop("Input metadata file (",file,") not found. Please check path and/or use list.files() to see files in current working directory.")}
+
   suppressWarnings(
   if(grepl("^#q2:types", readLines(file)[2])){return(TRUE)}else{return(FALSE)}
   )


### PR DESCRIPTION
Provide users with a more informative error message in case where metadata file passed to `qza_to_phyloseq` doesn't exist, as mentioned in the issue #62.