### PR TITLE
Support for reading ANCOM-BC results (#68)

### DIFF
--- a/R/read_qza.R
+++ b/R/read_qza.R
@@ -73,6 +73,12 @@ if(grepl("BIOMV", artifact$format)){
   coltitles<-strsplit(suppressWarnings(readLines(paste0(tmp, "/", artifact$uuid, "/data/differentials.tsv"))[1]), split='\t')[[1]]
   artifact$data<-read.table(paste0(tmp, "/", artifact$uuid, "/data/differentials.tsv"), header=F, col.names=coltitles, skip=2, sep='\t', colClasses = defline, check.names = FALSE)
   colnames(artifact$data)[1]<-"Feature.ID"
+} else if (artifact$format=="DataLoafPackageDirFmt"){
+  for (outs in list.files(paste0(tmp,"/", artifact$uuid,"/data"), full.names = TRUE, pattern = "_slice\\.csv$")){
+    NewLab <- gsub("_slice\\.csv$", "", basename(outs))
+    artifact$data[[NewLab]] <- read.table(outs, sep=",", header=TRUE)
+    colnames(artifact$data[[NewLab]]) <- gsub("X.Intercept.", "Intercept", colnames(artifact$data[[NewLab]]))
+  }
 } else {
   message("Format not supported, only a list of internal files and provenance is being imported.")
   artifact$data<-list.files(paste0(tmp,"/",artifact$uuid, "/data"))

--- a/R/read_qza.R
+++ b/R/read_qza.R
@@ -73,11 +73,11 @@ if(grepl("BIOMV", artifact$format)){
   coltitles<-strsplit(suppressWarnings(readLines(paste0(tmp, "/", artifact$uuid, "/data/differentials.tsv"))[1]), split='\t')[[1]]
   artifact$data<-read.table(paste0(tmp, "/", artifact$uuid, "/data/differentials.tsv"), header=F, col.names=coltitles, skip=2, sep='\t', colClasses = defline, check.names = FALSE)
   colnames(artifact$data)[1]<-"Feature.ID"
-} else if (artifact$format=="DataLoafPackageDirFmt"){
-  for (outs in list.files(paste0(tmp,"/", artifact$uuid,"/data"), full.names = TRUE, pattern = "_slice\\.csv$")){
-    NewLab <- gsub("_slice\\.csv$", "", basename(outs))
-    artifact$data[[NewLab]] <- read.table(outs, sep=",", header=TRUE)
-    colnames(artifact$data[[NewLab]]) <- gsub("X.Intercept.", "Intercept", colnames(artifact$data[[NewLab]]))
+} else if (artifact$format=="DataLoafPackageDirFmt") {
+  for (outs in list.files(paste0(tmp, "/", artifact$uuid, "/data"), full.names = TRUE, pattern = "_slice\\.csv$")){
+    NewLab<-gsub("_slice\\.csv$", "", basename(outs))
+    artifact$data[[NewLab]]<-read.table(outs, sep=",", header=TRUE)
+    colnames(artifact$data[[NewLab]])<-gsub("X.Intercept.", "Intercept", colnames(artifact$data[[NewLab]]))
   }
 } else {
   message("Format not supported, only a list of internal files and provenance is being imported.")


### PR DESCRIPTION
### Description:

This PR addresses the issue described in #68 where the current `read_qza` function does not support reading ANCOM-BC results (`qiime composition ancombc`). This update adds the necessary functionality to enable `read_qza` to correctly interpret and handle the multiple CSV files present in the QZA file.

### Changes Made:

- `read_qza.R`:
  -  Included "DataLoafPackageDirFmt" as a valid format.
  -  Parsed CSV files included in ANCOM-BC result QZA file, so `artifact$data` is a list of data.frame objects
  -  Renamed Intercept column in resulting data.frame objects since original column name, "(Intercept)", was being read in R as "X.Intercept." Columns are now renamed as simply "Intercept".

### Related Issue:

- Closes #68 